### PR TITLE
Fix #9: Last heartbeat time is off by UTC offset in UI

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -434,9 +434,10 @@
     /** Normalize timestamp to milliseconds (handles both seconds, milliseconds, and ISO date strings) */
     function normalizeTs(t) {
         if (!t) return 0;
-        // Handle ISO date strings from SQLite
+        // Handle ISO date strings from SQLite (stored as UTC)
         if (typeof t === 'string') {
-            const d = new Date(t);
+            const iso = t.includes('Z') ? t : t + 'Z';
+            const d = new Date(iso);
             if (!isNaN(d.getTime())) return d.getTime();
             return 0;
         }


### PR DESCRIPTION
Resolves #9

The issue was in the JavaScript  function which was interpreting SQLite datetime strings as local time instead of UTC. This fix appends 'Z' to string timestamps to ensure JavaScript treats them as UTC.