### PR TITLE
Fix #10: Acknowledge reaction and comment not working

### DIFF
--- a/cmd/flock/main.go
+++ b/cmd/flock/main.go
@@ -57,7 +57,7 @@ func main() {
 	broker := server.NewSSEBroker()
 
 	// Create agent harness
-	harness := agent.NewHarness(client, queries, cfg.Agent, broker.SubscribeInternal)
+	harness := agent.NewHarness(client, queries, cfg.Agent, broker.SubscribeInternal, cfg.Agent.DataDir)
 	harness.Start()
 
 	// Create instance manager with shared client

--- a/internal/agent/decisions.go
+++ b/internal/agent/decisions.go
@@ -17,10 +17,11 @@ type DecisionProcessor struct {
 	client     *opencode.Client
 	queries    *sqlc.Queries
 	workingDir string
+	dataDir    string
 }
 
-func NewDecisionProcessor(client *opencode.Client, queries *sqlc.Queries, workingDir string) *DecisionProcessor {
-	return &DecisionProcessor{client: client, queries: queries, workingDir: workingDir}
+func NewDecisionProcessor(client *opencode.Client, queries *sqlc.Queries, workingDir, dataDir string) *DecisionProcessor {
+	return &DecisionProcessor{client: client, queries: queries, workingDir: workingDir, dataDir: dataDir}
 }
 
 // ProcessDecisions reads decision files from the working directory,
@@ -39,7 +40,7 @@ func (dp *DecisionProcessor) processNewTasks(ctx context.Context, instanceID, wo
 		return
 	}
 
-	gh := NewGitHub(workingDir)
+	gh := NewGitHub(dp.dataDir)
 
 	for _, d := range decisions {
 		// Dedup: check if task already exists for this issue

--- a/internal/agent/harness.go
+++ b/internal/agent/harness.go
@@ -23,6 +23,7 @@ type Harness struct {
 	cancel     context.CancelFunc
 	// subscribeFn is set by the caller to provide internal SSE subscriptions.
 	subscribeFn func(sessionID string) (<-chan string, func())
+	dataDir    string
 }
 
 // NewHarness creates a new agent harness.
@@ -31,6 +32,7 @@ func NewHarness(
 	queries *sqlc.Queries,
 	cfg AgentConfig,
 	subscribeFn func(sessionID string) (<-chan string, func()),
+	dataDir string,
 ) *Harness {
 	cfg.Resolve()
 	return &Harness{
@@ -40,6 +42,7 @@ func NewHarness(
 		queries:     queries,
 		cfg:         cfg,
 		subscribeFn: subscribeFn,
+		dataDir:    dataDir,
 	}
 }
 
@@ -83,7 +86,7 @@ func (h *Harness) StartInstance(instanceID, workingDir string) {
 	}
 
 	orch := NewOrchestrator(h.client, h.queries, instanceID, workingDir, h.cfg, h.subscribeFn)
-	proc := NewDecisionProcessor(h.client, h.queries, workingDir)
+	proc := NewDecisionProcessor(h.client, h.queries, workingDir, h.dataDir)
 	sched := NewScheduler(instanceID, workingDir, h.cfg, orch, proc, h.queries, h.client)
 	sched.Start(h.ctx)
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -5,6 +5,7 @@ import "time"
 // AgentConfig holds configuration for the agent harness.
 type AgentConfig struct {
 	Enabled                 bool          `toml:"enabled"`
+	DataDir                 string        `toml:"data_dir"`
 	HeartbeatInterval       time.Duration `toml:"-"`
 	HeartbeatIntervalSecs   int           `toml:"heartbeat_interval_secs"`
 	StuckThresholdSecs      int           `toml:"stuck_threshold_secs"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,9 +48,14 @@ func Load(configPath string) *Config {
 	}
 	if v := os.Getenv("FLOCK_DATA_DIR"); v != "" {
 		cfg.DataDir = v
+		cfg.Agent.DataDir = v
 	}
 	if os.Getenv("FLOCK_AGENT_ENABLED") == "true" {
 		cfg.Agent.Enabled = true
+	}
+
+	if cfg.Agent.DataDir == "" {
+		cfg.Agent.DataDir = cfg.DataDir
 	}
 
 	return cfg


### PR DESCRIPTION
## Summary
- Fixed the GitHub client using the wrong working directory for `gh` commands
- The instance's working directory (under `.flock/instances/`) is not a git repository, causing "github: no repo configured" errors
- Now uses the main flock data directory (which is the git repository) for GitHub operations

## Changes
- Added `DataDir` field to `AgentConfig` to track the main flock directory
- Modified `Harness` and `DecisionProcessor` to pass the data directory to the GitHub client
- Updated config loading to ensure `Agent.DataDir` is properly set

Resolves #10