### PR TITLE
Fix #15: When we mark a task as closed or completed, clean up its local worktree

### DIFF
--- a/internal/agent/decisions.go
+++ b/internal/agent/decisions.go
@@ -2,7 +2,11 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/nbitslabs/flock/internal/db/sqlc"
@@ -83,6 +87,12 @@ func (dp *DecisionProcessor) processCompletedTasks(ctx context.Context, instance
 	}
 
 	for _, d := range decisions {
+		task, err := dp.queries.GetTaskByID(ctx, d.TaskID)
+		if err != nil {
+			log.Printf("agent: failed to get task %s: %v", d.TaskID, err)
+			continue
+		}
+
 		if err := dp.queries.UpdateTaskStatus(ctx, sqlc.UpdateTaskStatusParams{
 			Status: "completed",
 			ID:     d.TaskID,
@@ -90,6 +100,11 @@ func (dp *DecisionProcessor) processCompletedTasks(ctx context.Context, instance
 			log.Printf("agent: failed to mark task %s as completed: %v", d.TaskID, err)
 			continue
 		}
+
+		if err := removeWorktree(workingDir, task.BranchName); err != nil {
+			log.Printf("agent: failed to remove worktree for branch %s: %v", task.BranchName, err)
+		}
+
 		log.Printf("agent: marked task %s as completed (%s)", truncID(d.TaskID), d.Reason)
 	}
 }
@@ -118,4 +133,22 @@ func (dp *DecisionProcessor) processRestarts(ctx context.Context, instanceID, wo
 			}
 		}
 	}
+}
+
+func removeWorktree(workingDir, branchName string) error {
+	worktreePath := filepath.Join(workingDir, ".flock", "worktrees", branchName)
+
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		return nil
+	}
+
+	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
+	cmd.Dir = workingDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree remove failed: %w, output: %s", err, string(output))
+	}
+
+	log.Printf("agent: removed worktree at %s", worktreePath)
+	return nil
 }

--- a/internal/agent/harness.go
+++ b/internal/agent/harness.go
@@ -23,7 +23,7 @@ type Harness struct {
 	cancel     context.CancelFunc
 	// subscribeFn is set by the caller to provide internal SSE subscriptions.
 	subscribeFn func(sessionID string) (<-chan string, func())
-	dataDir    string
+	dataDir     string
 }
 
 // NewHarness creates a new agent harness.
@@ -42,7 +42,7 @@ func NewHarness(
 		queries:     queries,
 		cfg:         cfg,
 		subscribeFn: subscribeFn,
-		dataDir:    dataDir,
+		dataDir:     dataDir,
 	}
 }
 

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -49,6 +49,9 @@ RETURNING *;
 -- name: GetTaskByIssue :one
 SELECT * FROM tasks WHERE instance_id = ? AND issue_number = ?;
 
+-- name: GetTaskByID :one
+SELECT * FROM tasks WHERE id = ?;
+
 -- name: ListTasksByInstance :many
 SELECT * FROM tasks WHERE instance_id = ? ORDER BY created_at DESC;
 

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -254,6 +254,30 @@ func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
 	return i, err
 }
 
+const getTaskByID = `-- name: GetTaskByID :one
+SELECT id, instance_id, issue_number, issue_url, title, status, session_id, branch_name, pr_url, last_activity_at, created_at, updated_at FROM tasks WHERE id = ?
+`
+
+func (q *Queries) GetTaskByID(ctx context.Context, id string) (Task, error) {
+	row := q.db.QueryRowContext(ctx, getTaskByID, id)
+	var i Task
+	err := row.Scan(
+		&i.ID,
+		&i.InstanceID,
+		&i.IssueNumber,
+		&i.IssueUrl,
+		&i.Title,
+		&i.Status,
+		&i.SessionID,
+		&i.BranchName,
+		&i.PrUrl,
+		&i.LastActivityAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getTaskByIssue = `-- name: GetTaskByIssue :one
 SELECT id, instance_id, issue_number, issue_url, title, status, session_id, branch_name, pr_url, last_activity_at, created_at, updated_at FROM tasks WHERE instance_id = ? AND issue_number = ?
 `


### PR DESCRIPTION
## Summary
When a task is marked as completed (either by the issue being closed or the PR being merged), the local git worktree is now automatically cleaned up.

## Changes
- Added `GetTaskByID` SQL query to fetch task details including branch name
- Updated `processCompletedTasks` in decisions.go to clean up worktree after marking task complete
- Added `removeWorktree` function that uses `git worktree remove --force`

## Behavior
When the orchestrator marks a task as completed (via `completed_tasks.json`), the local worktree at `.flock/worktrees/{branchName}` is automatically removed. The branch itself is NOT deleted, leaving the remote branch intact for review.

Resolves #15