### PR TITLE
Fix #23: Short heartbeats always show "Just now"

### DIFF
--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -92,7 +92,7 @@ LIMIT 1;
 
 -- name: IncrementHeartbeatCount :exec
 UPDATE orchestrator_sessions
-SET heartbeat_count = heartbeat_count + 1, last_heartbeat_at = datetime('now'), updated_at = datetime('now')
+SET heartbeat_count = heartbeat_count + 1, last_heartbeat_at = datetime('now', 'utc'), updated_at = datetime('now', 'utc')
 WHERE id = ?;
 
 -- name: RetireOrchestratorSession :exec

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -309,7 +309,7 @@ func (q *Queries) GetTaskByIssue(ctx context.Context, arg GetTaskByIssueParams) 
 
 const incrementHeartbeatCount = `-- name: IncrementHeartbeatCount :exec
 UPDATE orchestrator_sessions
-SET heartbeat_count = heartbeat_count + 1, last_heartbeat_at = datetime('now'), updated_at = datetime('now')
+SET heartbeat_count = heartbeat_count + 1, last_heartbeat_at = datetime('now', 'utc'), updated_at = datetime('now', 'utc')
 WHERE id = ?
 `
 


### PR DESCRIPTION
## Summary

- Changed SQLite to store heartbeat timestamps in UTC using `datetime('now', 'utc')` instead of local time
- This fixes the issue where short heartbeats always showed "Just now" regardless of the actual elapsed time

## Root Cause

SQLite's `datetime('now')` returns local server time, but the frontend was treating it as UTC by appending 'Z' to parse it. This caused the displayed time to be in the future (due to timezone offset), resulting in 'just now' being shown for all heartbeats because the diff calculation produced a negative value.

## Changes

- `internal/db/queries.sql`: Changed `datetime('now')` to `datetime('now', 'utc')` for the heartbeat timestamp
- `internal/db/sqlc/queries.sql.go`: Regenerated (manually edited to match the SQL change)

Resolves #23