### PR TITLE
Fix #27: Create flock agent session

### DIFF
--- a/cmd/flock/main.go
+++ b/cmd/flock/main.go
@@ -89,8 +89,8 @@ func main() {
 	// Start global event subscription to the OpenCode server
 	manager.StartEventSubscription()
 
-	// Create HTTP server
-	srv := server.New(queries, manager, broker, harness, cfg.DataDir)
+	// Create HTTP server (reuse same client for flock agent - it uses the data dir as working dir)
+	srv := server.New(queries, manager, broker, harness, cfg.DataDir, client)
 	httpServer := &http.Server{
 		Addr:    cfg.Addr,
 		Handler: srv,

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -108,3 +108,22 @@ SELECT last_heartbeat_at FROM orchestrator_sessions
 WHERE instance_id = ? AND status = 'active'
 ORDER BY last_heartbeat_at DESC
 LIMIT 1;
+
+-- Flock agent session queries
+
+-- name: CreateFlockAgentSession :one
+INSERT INTO flock_agent_sessions (id, session_id, working_directory, status)
+VALUES (?, ?, ?, 'active')
+RETURNING *;
+
+-- name: GetFlockAgentSession :one
+SELECT * FROM flock_agent_sessions WHERE id = ?;
+
+-- name: GetActiveFlockAgentSession :one
+SELECT * FROM flock_agent_sessions WHERE status = 'active' LIMIT 1;
+
+-- name: UpdateFlockAgentSession :exec
+UPDATE flock_agent_sessions SET session_id = ?, status = ?, updated_at = datetime('now') WHERE id = ?;
+
+-- name: RetireFlockAgentSession :exec
+UPDATE flock_agent_sessions SET status = 'retired', updated_at = datetime('now') WHERE id = ?;

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -4,6 +4,15 @@
 
 package sqlc
 
+type FlockAgentSession struct {
+	ID               string
+	SessionID        string
+	WorkingDirectory string
+	Status           string
+	CreatedAt        string
+	UpdatedAt        string
+}
+
 type Instance struct {
 	ID               string
 	Pid              int64

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -9,6 +9,34 @@ import (
 	"context"
 )
 
+const createFlockAgentSession = `-- name: CreateFlockAgentSession :one
+
+INSERT INTO flock_agent_sessions (id, session_id, working_directory, status)
+VALUES (?, ?, ?, 'active')
+RETURNING id, session_id, working_directory, status, created_at, updated_at
+`
+
+type CreateFlockAgentSessionParams struct {
+	ID               string
+	SessionID        string
+	WorkingDirectory string
+}
+
+// Flock agent session queries
+func (q *Queries) CreateFlockAgentSession(ctx context.Context, arg CreateFlockAgentSessionParams) (FlockAgentSession, error) {
+	row := q.db.QueryRowContext(ctx, createFlockAgentSession, arg.ID, arg.SessionID, arg.WorkingDirectory)
+	var i FlockAgentSession
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.WorkingDirectory,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createInstance = `-- name: CreateInstance :one
 INSERT INTO instances (id, pid, port, working_directory, status)
 VALUES (?, 0, 0, ?, 'running')
@@ -181,6 +209,24 @@ func (q *Queries) DeleteTasksByInstance(ctx context.Context, instanceID string) 
 	return err
 }
 
+const getActiveFlockAgentSession = `-- name: GetActiveFlockAgentSession :one
+SELECT id, session_id, working_directory, status, created_at, updated_at FROM flock_agent_sessions WHERE status = 'active' LIMIT 1
+`
+
+func (q *Queries) GetActiveFlockAgentSession(ctx context.Context) (FlockAgentSession, error) {
+	row := q.db.QueryRowContext(ctx, getActiveFlockAgentSession)
+	var i FlockAgentSession
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.WorkingDirectory,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getActiveOrchestratorSession = `-- name: GetActiveOrchestratorSession :one
 SELECT id, instance_id, session_id, heartbeat_count, status, created_at, updated_at, last_heartbeat_at FROM orchestrator_sessions
 WHERE instance_id = ? AND status = 'active'
@@ -199,6 +245,24 @@ func (q *Queries) GetActiveOrchestratorSession(ctx context.Context, instanceID s
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastHeartbeatAt,
+	)
+	return i, err
+}
+
+const getFlockAgentSession = `-- name: GetFlockAgentSession :one
+SELECT id, session_id, working_directory, status, created_at, updated_at FROM flock_agent_sessions WHERE id = ?
+`
+
+func (q *Queries) GetFlockAgentSession(ctx context.Context, id string) (FlockAgentSession, error) {
+	row := q.db.QueryRowContext(ctx, getFlockAgentSession, id)
+	var i FlockAgentSession
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.WorkingDirectory,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -514,6 +578,15 @@ func (q *Queries) ListTasksByInstance(ctx context.Context, instanceID string) ([
 	return items, nil
 }
 
+const retireFlockAgentSession = `-- name: RetireFlockAgentSession :exec
+UPDATE flock_agent_sessions SET status = 'retired', updated_at = datetime('now') WHERE id = ?
+`
+
+func (q *Queries) RetireFlockAgentSession(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, retireFlockAgentSession, id)
+	return err
+}
+
 const retireOrchestratorSession = `-- name: RetireOrchestratorSession :exec
 UPDATE orchestrator_sessions
 SET status = 'retired', updated_at = datetime('now')
@@ -522,6 +595,21 @@ WHERE id = ?
 
 func (q *Queries) RetireOrchestratorSession(ctx context.Context, id string) error {
 	_, err := q.db.ExecContext(ctx, retireOrchestratorSession, id)
+	return err
+}
+
+const updateFlockAgentSession = `-- name: UpdateFlockAgentSession :exec
+UPDATE flock_agent_sessions SET session_id = ?, status = ?, updated_at = datetime('now') WHERE id = ?
+`
+
+type UpdateFlockAgentSessionParams struct {
+	SessionID string
+	Status    string
+	ID        string
+}
+
+func (q *Queries) UpdateFlockAgentSession(ctx context.Context, arg UpdateFlockAgentSessionParams) error {
+	_, err := q.db.ExecContext(ctx, updateFlockAgentSession, arg.SessionID, arg.Status, arg.ID)
 	return err
 }
 

--- a/internal/server/handlers_agent.go
+++ b/internal/server/handlers_agent.go
@@ -3,8 +3,11 @@ package server
 import (
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 
+	"github.com/google/uuid"
+	"github.com/nbitslabs/flock/internal/db/sqlc"
 	"github.com/nbitslabs/flock/internal/memory"
 )
 
@@ -147,4 +150,151 @@ func (s *Server) handleGetAgentStatus(w http.ResponseWriter, r *http.Request) {
 	data, _ := json.Marshal(status)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+// handleGetFlockAgentSession returns the current Flock agent session.
+func (s *Server) handleGetFlockAgentSession(w http.ResponseWriter, r *http.Request) {
+	session, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	if err != nil {
+		writeJSON(w, map[string]any{"active": false})
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"active": true,
+		"id":     session.ID,
+		"status": session.Status,
+	})
+}
+
+// handleCreateFlockAgentSession creates a new Flock agent session.
+func (s *Server) handleCreateFlockAgentSession(w http.ResponseWriter, r *http.Request) {
+	activeSession, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	if err == nil && activeSession.Status == "active" {
+		writeJSON(w, map[string]any{
+			"id":     activeSession.ID,
+			"status": activeSession.Status,
+		})
+		return
+	}
+
+	ocSession, err := s.flockAgentClient.CreateSession(r.Context())
+	if err != nil {
+		log.Printf("failed to create flock agent session: %v", err)
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+
+	sessionID := ocSession.ID
+	if sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
+	flockAgentID := uuid.New().String()
+	_, err = s.queries.CreateFlockAgentSession(r.Context(), sqlc.CreateFlockAgentSessionParams{
+		ID:               flockAgentID,
+		SessionID:        sessionID,
+		WorkingDirectory: s.dataDir,
+	})
+	if err != nil {
+		log.Printf("failed to save flock agent session: %v", err)
+		http.Error(w, "failed to save session", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"id":     flockAgentID,
+		"session_id": sessionID,
+		"status": "active",
+	})
+}
+
+// handleRotateFlockAgentSession rotates (retires old and creates new) the Flock agent session.
+func (s *Server) handleRotateFlockAgentSession(w http.ResponseWriter, r *http.Request) {
+	activeSession, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	if err == nil && activeSession.Status == "active" {
+		s.queries.RetireFlockAgentSession(r.Context(), activeSession.ID)
+	}
+
+	ocSession, err := s.flockAgentClient.CreateSession(r.Context())
+	if err != nil {
+		log.Printf("failed to create flock agent session: %v", err)
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+
+	sessionID := ocSession.ID
+	if sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
+	flockAgentID := uuid.New().String()
+	_, err = s.queries.CreateFlockAgentSession(r.Context(), sqlc.CreateFlockAgentSessionParams{
+		ID:               flockAgentID,
+		SessionID:        sessionID,
+		WorkingDirectory: s.dataDir,
+	})
+	if err != nil {
+		log.Printf("failed to save flock agent session: %v", err)
+		http.Error(w, "failed to save session", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"id":     flockAgentID,
+		"session_id": sessionID,
+		"status": "active",
+	})
+}
+
+// handleGetFlockAgentMessages returns messages for the Flock agent session.
+func (s *Server) handleGetFlockAgentMessages(w http.ResponseWriter, r *http.Request) {
+	session, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	if err != nil {
+		http.Error(w, "no active session", http.StatusNotFound)
+		return
+	}
+
+	messages, err := s.flockAgentClient.GetMessages(r.Context(), session.SessionID)
+	if err != nil {
+		log.Printf("failed to get flock agent messages: %v", err)
+		http.Error(w, "failed to get messages", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, messages)
+}
+
+// handleSendFlockAgentMessage sends a message to the Flock agent session.
+func (s *Server) handleSendFlockAgentMessage(w http.ResponseWriter, r *http.Request) {
+	session, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	if err != nil {
+		http.Error(w, "no active session", http.StatusNotFound)
+		return
+	}
+
+	var req sendMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.flockAgentClient.SendMessage(r.Context(), session.SessionID, req.Content); err != nil {
+		log.Printf("failed to send flock agent message: %v", err)
+		http.Error(w, "failed to send message", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+	writeJSON(w, map[string]string{"status": "sent"})
+}
+
+// handleFlockAgentEvents returns SSE events for the Flock agent session.
+func (s *Server) handleFlockAgentEvents(w http.ResponseWriter, r *http.Request) {
+	session, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	if err != nil {
+		http.Error(w, "no active session", http.StatusNotFound)
+		return
+	}
+
+	s.broker.ServeHTTP(w, r, session.SessionID)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,23 +13,25 @@ import (
 )
 
 type Server struct {
-	mux     *http.ServeMux
-	queries *sqlc.Queries
-	manager *opencode.Manager
-	broker  *SSEBroker
-	harness *agent.Harness
-	dataDir string
-	tmpl    *template.Template
+	mux                *http.ServeMux
+	queries            *sqlc.Queries
+	manager            *opencode.Manager
+	broker             *SSEBroker
+	harness            *agent.Harness
+	dataDir            string
+	tmpl               *template.Template
+	flockAgentClient   *opencode.Client
 }
 
-func New(queries *sqlc.Queries, manager *opencode.Manager, broker *SSEBroker, harness *agent.Harness, dataDir string) *Server {
+func New(queries *sqlc.Queries, manager *opencode.Manager, broker *SSEBroker, harness *agent.Harness, dataDir string, flockAgentClient *opencode.Client) *Server {
 	s := &Server{
-		mux:     http.NewServeMux(),
-		queries: queries,
-		manager: manager,
-		broker:  broker,
-		harness: harness,
-		dataDir: dataDir,
+		mux:              http.NewServeMux(),
+		queries:          queries,
+		manager:          manager,
+		broker:           broker,
+		harness:          harness,
+		dataDir:          dataDir,
+		flockAgentClient: flockAgentClient,
 	}
 	s.setupRoutes()
 	return s
@@ -75,6 +77,14 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("GET /api/global-memory", s.handleGetGlobalMemory)
 	s.mux.HandleFunc("PUT /api/global-memory", s.handlePutGlobalMemory)
 	s.mux.HandleFunc("GET /api/agent/status", s.handleGetAgentStatus)
+
+	// Flock Agent API
+	s.mux.HandleFunc("GET /api/flock-agent", s.handleGetFlockAgentSession)
+	s.mux.HandleFunc("POST /api/flock-agent", s.handleCreateFlockAgentSession)
+	s.mux.HandleFunc("PUT /api/flock-agent/rotate", s.handleRotateFlockAgentSession)
+	s.mux.HandleFunc("GET /api/flock-agent/messages", s.handleGetFlockAgentMessages)
+	s.mux.HandleFunc("POST /api/flock-agent/messages", s.handleSendFlockAgentMessage)
+	s.mux.HandleFunc("GET /api/flock-agent/events", s.handleFlockAgentEvents)
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {

--- a/migrations/004_flock_agent_session.sql
+++ b/migrations/004_flock_agent_session.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+CREATE TABLE flock_agent_sessions (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    working_directory TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- +goose Down
+DROP TABLE flock_agent_sessions;

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -12,6 +12,9 @@
         messages: new Map(),       // msgID -> message
         streamingParts: new Map(), // partID -> accumulated part
 
+        flockAgentActive: false,
+        flockAgentId: null,
+        flockAgentSessionId: null,
         selectedInstanceId: null,
         selectedSessionId: null,
         sessionBusy: false,
@@ -21,6 +24,7 @@
         _lastSentText: null,  // track user message to filter streaming echoes
         _sessionHash: '',
         _darkMode: true,
+        _flockAgentHash: '',
     };
 
     // =========================================================================
@@ -298,6 +302,71 @@
         }
     }
 
+    // Flock Agent API
+    async function refreshFlockAgent() {
+        try {
+            const data = await api('GET', '/api/flock-agent') || {};
+            const hash = JSON.stringify([data.active, data.id, data.status]);
+            if (hash === store._flockAgentHash) return;
+            store._flockAgentHash = hash;
+            store.flockAgentActive = data.active;
+            store.flockAgentId = data.id;
+            store.flockAgentSessionId = data.session_id;
+            renderFlockAgent();
+        } catch (e) { console.error('refreshFlockAgent:', e); }
+    }
+
+    async function createFlockAgent() {
+        try {
+            await api('POST', '/api/flock-agent');
+            store._flockAgentHash = '';
+            await refreshFlockAgent();
+        } catch (e) { alert('Failed to create flock agent: ' + e.message); }
+    }
+
+    async function rotateFlockAgent() {
+        try {
+            await api('PUT', '/api/flock-agent/rotate');
+            store._flockAgentHash = '';
+            await refreshFlockAgent();
+        } catch (e) { alert('Failed to rotate flock agent: ' + e.message); }
+    }
+
+    async function loadFlockAgentMessages() {
+        try {
+            const msgs = await api('GET', '/api/flock-agent/messages') || [];
+            store.messages.clear();
+            for (const m of msgs) {
+                if (!m.info?.id) continue;
+                store.messages.set(m.info.id, m);
+            }
+            store.streamingParts.clear();
+            store._lastSentText = null;
+            renderMessages();
+        } catch (e) { console.error('loadFlockAgentMessages:', e); }
+    }
+
+    async function sendFlockAgentMessage(content) {
+        try {
+            await api('POST', '/api/flock-agent/messages', { content });
+        } catch (e) {
+            console.error('sendFlockAgentMessage:', e);
+            alert('Failed to send message: ' + e.message);
+            store.sessionBusy = false;
+            updateInputState();
+        }
+    }
+
+    function connectFlockAgentSSE() {
+        closeEventSource();
+        const es = new EventSource('/api/flock-agent/events');
+        store.eventSource = es;
+        es.onmessage = function (e) {
+            try { routeEvent(JSON.parse(e.data)); } catch (err) { /* ignore */ }
+        };
+        es.onerror = function () { /* auto-reconnects */ };
+    }
+
     // =========================================================================
     // Section 4 — SSE
     // =========================================================================
@@ -433,7 +502,25 @@
     function doSend() {
         const input = document.getElementById('message-input');
         const content = input.value.trim();
-        if (!content || !store.selectedSessionId || store.sessionBusy) return;
+        if (!content || store.sessionBusy) return;
+        if (store.flockAgentActive) {
+            input.value = '';
+            input.style.height = 'auto';
+            store._lastSentText = content;
+            const optId = '_opt_' + Date.now();
+            store.messages.set(optId, {
+                info: { id: optId, role: 'user', time: { created: Date.now() } },
+                parts: [{ type: 'text', text: content }],
+                _optimistic: true,
+            });
+            renderMessages();
+            scrollToBottom();
+            store.sessionBusy = true;
+            updateInputState();
+            sendFlockAgentMessage(content);
+            return;
+        }
+        if (!store.selectedSessionId) return;
         input.value = '';
         input.style.height = 'auto';
 
@@ -956,6 +1043,29 @@
     }
 
     // =========================================================================
+    // Section 8b — Flock Agent UI
+    // =========================================================================
+
+    function renderFlockAgent() {
+        const flockAgent = document.getElementById('flock-agent');
+        const flockAgentEmpty = document.getElementById('flock-agent-empty');
+        const btnRotate = document.getElementById('btn-flock-agent-rotate');
+        const btnNew = document.getElementById('btn-new-flock-agent');
+        if (!flockAgent || !flockAgentEmpty || !btnRotate || !btnNew) return;
+        if (store.flockAgentActive) {
+            flockAgent.classList.remove('hidden');
+            flockAgentEmpty.classList.add('hidden');
+            btnRotate.classList.remove('hidden');
+            btnNew.classList.add('hidden');
+        } else {
+            flockAgent.classList.add('hidden');
+            flockAgentEmpty.classList.remove('hidden');
+            btnRotate.classList.add('hidden');
+            btnNew.classList.remove('hidden');
+        }
+    }
+
+    // =========================================================================
     // Section 9 — Resize
     // =========================================================================
 
@@ -991,6 +1101,20 @@
         document.getElementById('input-area').classList.add('hidden');
         loadSessions(id);
         updateURL();
+    }
+
+    function selectFlockAgent() {
+        store.selectedInstanceId = null;
+        store.selectedSessionId = null;
+        store.sessions.clear(); store.messages.clear(); store.streamingParts.clear();
+        store.sessionBusy = false; store.sessionBusyTool = null;
+        closeEventSource();
+        renderInstances(); renderSessions(); renderMessages();
+        document.getElementById('btn-new-session').classList.add('hidden');
+        document.getElementById('input-area').classList.remove('hidden');
+        document.getElementById('main-header').textContent = 'Flock Agent';
+        loadFlockAgentMessages();
+        connectFlockAgentSSE();
     }
 
     function selectSession(id) {
@@ -1051,6 +1175,7 @@
             case 'select-instance': selectInstance(t.dataset.id); break;
             case 'delete-instance': e.stopPropagation(); if (confirm('Remove this instance?')) deleteInstance(t.dataset.id); break;
             case 'select-session': selectSession(t.dataset.id); break;
+            case 'select-flock-agent': selectFlockAgent(); break;
         }
     });
 
@@ -1071,6 +1196,12 @@
     });
     document.getElementById('btn-new-session').addEventListener('click', () => {
         if (store.selectedInstanceId) createSession(store.selectedInstanceId);
+    });
+    document.getElementById('btn-new-flock-agent').addEventListener('click', () => {
+        createFlockAgent();
+    });
+    document.getElementById('btn-flock-agent-rotate').addEventListener('click', () => {
+        if (confirm('Rotate session? This will start a new conversation.')) rotateFlockAgent();
     });
     document.getElementById('message-input').addEventListener('keydown', (e) => {
         if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); doSend(); }
@@ -1127,9 +1258,11 @@
     initMarkdown();
     initResize();
     refreshInstances();
+    refreshFlockAgent();
     restoreFromURL();
     setInterval(refreshInstances, 5000);
     setInterval(refreshSessions, 5000);
+    setInterval(refreshFlockAgent, 5000);
 
     document.getElementById('btn-theme-toggle').addEventListener('click', toggleTheme);
 })();

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -17,6 +17,30 @@
             <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Agent Orchestration</p>
         </div>
 
+        <!-- Flock Agent -->
+        <div class="p-3 border-b border-gray-200 dark:border-gray-800">
+            <div class="flex items-center justify-between mb-2">
+                <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-300 uppercase tracking-wider">Flock</h2>
+                <div class="flex items-center gap-2">
+                    <button id="btn-flock-agent-rotate" class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 px-2 py-1 hidden" title="Rotate session">
+                        ↻
+                    </button>
+                    <button id="btn-new-flock-agent" class="text-xs bg-purple-600 hover:bg-purple-700 text-white px-2 py-1 rounded">
+                        + New
+                    </button>
+                </div>
+            </div>
+            <div id="flock-agent" class="hidden">
+                <div class="flex items-center gap-2 px-2 py-1.5 rounded bg-purple-100 dark:bg-purple-900/30 cursor-pointer" data-action="select-flock-agent">
+                    <span class="w-2 h-2 rounded-full bg-purple-500 flex-shrink-0"></span>
+                    <span class="text-sm truncate text-purple-700 dark:text-purple-300">Flock Agent</span>
+                </div>
+            </div>
+            <div id="flock-agent-empty" class="text-xs text-gray-400 dark:text-gray-500 px-2 py-1">
+                No agent session
+            </div>
+        </div>
+
         <!-- Instances -->
         <div class="flex-1 overflow-y-auto custom-scrollbar">
             <div class="p-3">


### PR DESCRIPTION
## Summary
- Implements a Flock agent that users can chat with to manage instances
- Backend adds `flock_agent_sessions` table and API endpoints for session management
- Frontend adds Flock agent section in sidebar with New/Rotate buttons
- Reuses OpenCode client for communicating with the agent

## Changes
- New migration: `004_flock_agent_session.sql`
- Backend handlers for creating/rotating sessions, messaging, and SSE events
- Frontend UI and event handling for Flock agent interactions