### PR TITLE
Fix #29: The state directory should detect its presence

### DIFF
--- a/internal/agent/decisions.go
+++ b/internal/agent/decisions.go
@@ -131,7 +131,7 @@ func (dp *DecisionProcessor) processRestarts(ctx context.Context, instanceID, wo
 }
 
 func removeWorktree(workingDir, branchName string) error {
-	worktreePath := filepath.Join(workingDir, ".flock", "worktrees", branchName)
+	worktreePath := filepath.Join(memory.ResolveStateDir(workingDir), "worktrees", branchName)
 
 	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
 		return nil

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -72,7 +72,7 @@ func CreateSubAgentSession(
 }
 
 func composeSubAgentPrompt(workingDir string, task *sqlc.Task) string {
-	worktreeDir := fmt.Sprintf("%s/.flock/worktrees/%s", workingDir, task.BranchName)
+	worktreeDir := fmt.Sprintf("%s/worktrees/%s", memory.ResolveStateDir(workingDir), task.BranchName)
 
 	return fmt.Sprintf(`You are an autonomous coding agent resolving a GitHub issue. Work independently to completion.
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -17,6 +18,16 @@ const (
 	restartFile   = "restart_tasks.json"
 	completedFile = "completed_tasks.json"
 )
+
+// ResolveStateDir returns the state directory path.
+// If the given path already ends with ".flock", it is returned as-is.
+// Otherwise, ".flock" is appended to the path.
+func ResolveStateDir(dataDir string) string {
+	if strings.HasSuffix(dataDir, flockDir) {
+		return dataDir
+	}
+	return filepath.Join(dataDir, flockDir)
+}
 
 // NewTaskDecision represents a new task from the orchestrator's decision file.
 type NewTaskDecision struct {
@@ -40,11 +51,13 @@ type CompletedTaskDecision struct {
 
 // EnsureLayout creates the .flock directory structure and default files if they
 // don't already exist. workingDir is the instance's working directory.
+// It detects if workingDir already ends with ".flock" to avoid nesting.
 func EnsureLayout(workingDir string) error {
+	stateDir := ResolveStateDir(workingDir)
 	dirs := []string{
-		filepath.Join(workingDir, flockDir),
-		filepath.Join(workingDir, memoryDir),
-		filepath.Join(workingDir, progressDir),
+		stateDir,
+		filepath.Join(stateDir, "memory"),
+		filepath.Join(stateDir, "memory", "progress"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {
@@ -53,7 +66,7 @@ func EnsureLayout(workingDir string) error {
 	}
 
 	// Write default HEARTBEAT.md if missing
-	hbPath := filepath.Join(workingDir, flockDir, heartbeatFile)
+	hbPath := filepath.Join(stateDir, heartbeatFile)
 	if _, err := os.Stat(hbPath); os.IsNotExist(err) {
 		if err := os.WriteFile(hbPath, []byte(defaultHeartbeat()), 0o644); err != nil {
 			return fmt.Errorf("write heartbeat: %w", err)
@@ -61,7 +74,7 @@ func EnsureLayout(workingDir string) error {
 	}
 
 	// Write default MEMORY.md if missing
-	memPath := filepath.Join(workingDir, memoryDir, memoryFile)
+	memPath := filepath.Join(stateDir, "memory", memoryFile)
 	if _, err := os.Stat(memPath); os.IsNotExist(err) {
 		if err := os.WriteFile(memPath, []byte(defaultMemory()), 0o644); err != nil {
 			return fmt.Errorf("write memory: %w", err)
@@ -73,7 +86,7 @@ func EnsureLayout(workingDir string) error {
 
 // ReadHeartbeat returns the contents of .flock/HEARTBEAT.md.
 func ReadHeartbeat(workingDir string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(workingDir, flockDir, heartbeatFile))
+	data, err := os.ReadFile(filepath.Join(ResolveStateDir(workingDir), heartbeatFile))
 	if err != nil {
 		return "", err
 	}
@@ -82,12 +95,12 @@ func ReadHeartbeat(workingDir string) (string, error) {
 
 // WriteHeartbeat writes content to .flock/HEARTBEAT.md.
 func WriteHeartbeat(workingDir, content string) error {
-	return os.WriteFile(filepath.Join(workingDir, flockDir, heartbeatFile), []byte(content), 0o644)
+	return os.WriteFile(filepath.Join(ResolveStateDir(workingDir), heartbeatFile), []byte(content), 0o644)
 }
 
 // ReadInstanceMemory returns the contents of .flock/memory/MEMORY.md.
 func ReadInstanceMemory(workingDir string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(workingDir, memoryDir, memoryFile))
+	data, err := os.ReadFile(filepath.Join(ResolveStateDir(workingDir), "memory", memoryFile))
 	if err != nil {
 		return "", err
 	}
@@ -96,7 +109,7 @@ func ReadInstanceMemory(workingDir string) (string, error) {
 
 // ReadGlobalMemory returns the global memory file from the data directory.
 func ReadGlobalMemory(dataDir string) (string, error) {
-	path := filepath.Join(dataDir, "memory", memoryFile)
+	path := filepath.Join(ResolveStateDir(dataDir), "memory", memoryFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -109,7 +122,7 @@ func ReadGlobalMemory(dataDir string) (string, error) {
 
 // WriteGlobalMemory writes the global memory file in the data directory.
 func WriteGlobalMemory(dataDir, content string) error {
-	dir := filepath.Join(dataDir, "memory")
+	dir := filepath.Join(ResolveStateDir(dataDir), "memory")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -118,7 +131,7 @@ func WriteGlobalMemory(dataDir, content string) error {
 
 // ReadNewTasks reads and parses .flock/memory/new_tasks.json.
 func ReadNewTasks(workingDir string) ([]NewTaskDecision, error) {
-	path := filepath.Join(workingDir, memoryDir, newTasksFile)
+	path := filepath.Join(ResolveStateDir(workingDir), "memory", newTasksFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -135,7 +148,7 @@ func ReadNewTasks(workingDir string) ([]NewTaskDecision, error) {
 
 // ReadRestartTasks reads and parses .flock/memory/restart_tasks.json.
 func ReadRestartTasks(workingDir string) ([]RestartTaskDecision, error) {
-	path := filepath.Join(workingDir, memoryDir, restartFile)
+	path := filepath.Join(ResolveStateDir(workingDir), "memory", restartFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -152,7 +165,7 @@ func ReadRestartTasks(workingDir string) ([]RestartTaskDecision, error) {
 
 // ReadCompletedTasks reads and parses .flock/memory/completed_tasks.json.
 func ReadCompletedTasks(workingDir string) ([]CompletedTaskDecision, error) {
-	path := filepath.Join(workingDir, memoryDir, completedFile)
+	path := filepath.Join(ResolveStateDir(workingDir), "memory", completedFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -169,7 +182,7 @@ func ReadCompletedTasks(workingDir string) ([]CompletedTaskDecision, error) {
 
 // ClearDecisionFiles removes the decision files after processing.
 func ClearDecisionFiles(workingDir string) {
-	os.Remove(filepath.Join(workingDir, memoryDir, newTasksFile))
-	os.Remove(filepath.Join(workingDir, memoryDir, restartFile))
-	os.Remove(filepath.Join(workingDir, memoryDir, completedFile))
+	os.Remove(filepath.Join(ResolveStateDir(workingDir), "memory", newTasksFile))
+	os.Remove(filepath.Join(ResolveStateDir(workingDir), "memory", restartFile))
+	os.Remove(filepath.Join(ResolveStateDir(workingDir), "memory", completedFile))
 }

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,0 +1,81 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveStateDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "regular directory",
+			input:    "/Users/test/project",
+			expected: "/Users/test/project/.flock",
+		},
+		{
+			name:     "directory already ending with .flock",
+			input:    "/Users/test/project/.flock",
+			expected: "/Users/test/project/.flock",
+		},
+		{
+			name:     "current directory",
+			input:    ".",
+			expected: ".flock",
+		},
+		{
+			name:     "current directory with .flock",
+			input:    ".flock",
+			expected: ".flock",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveStateDir(tt.input)
+			if result != tt.expected {
+				t.Errorf("ResolveStateDir(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnsureLayoutWithFlockSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	flockDir := filepath.Join(tmpDir, ".flock")
+	if err := os.MkdirAll(flockDir, 0o755); err != nil {
+		t.Fatalf("failed to create .flock dir: %v", err)
+	}
+
+	if err := EnsureLayout(tmpDir); err != nil {
+		t.Fatalf("EnsureLayout failed: %v", err)
+	}
+
+	expectedMemoryDir := filepath.Join(flockDir, "memory")
+	if _, err := os.Stat(expectedMemoryDir); os.IsNotExist(err) {
+		t.Errorf("expected memory dir at %s, but it doesn't exist", expectedMemoryDir)
+	}
+
+	wrongMemoryDir := filepath.Join(flockDir, ".flock", "memory")
+	if _, err := os.Stat(wrongMemoryDir); !os.IsNotExist(err) {
+		t.Errorf("found nested .flock directory at %s, should not exist", wrongMemoryDir)
+	}
+}
+
+func TestEnsureLayoutWithoutFlockSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := EnsureLayout(tmpDir); err != nil {
+		t.Fatalf("EnsureLayout failed: %v", err)
+	}
+
+	expectedMemoryDir := filepath.Join(tmpDir, ".flock", "memory")
+	if _, err := os.Stat(expectedMemoryDir); os.IsNotExist(err) {
+		t.Errorf("expected memory dir at %s, but it doesn't exist", expectedMemoryDir)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ResolveStateDir` function that detects if a path already ends with `.flock` and returns it as-is, otherwise appends `.flock`
- Update all memory functions to use this helper to avoid creating nested `.flock/.flock` directories
- Update agent worktree path handling to use the same logic

This allows users to specify either `/User/temp` or `/User/temp/.flock` as the data directory without creating nested directories.

Resolves #29