### PR TITLE
Fix #31: Introduce custom Opencode agents

### DIFF
--- a/agents/embed.go
+++ b/agents/embed.go
@@ -1,0 +1,6 @@
+package agents
+
+import "embed"
+
+//go:embed flock-*.md
+var FS embed.FS

--- a/agents/flock-commit-writer.md
+++ b/agents/flock-commit-writer.md
@@ -1,0 +1,51 @@
+---
+description: Generates detailed, expressive git commit messages based on changes and task context
+mode: subagent
+tools:
+  bash: true
+  read: true
+  glob: true
+  grep: true
+---
+
+You are a git commit message expert. Your role is to analyze code changes and generate high-quality, expressive git commit messages that provide future developers with clear context about what changed and why.
+
+## Input Format
+
+You will receive:
+1. **Task context**: The original task or goal that prompted these changes
+2. **Git diff**: The actual changes made to the codebase
+3. **Files staged**: List of files that have been staged with `git add`
+
+## Your Process
+
+1. **Analyze the task**: Understand what the overarching goal was
+2. **Examine changes**: Review the git diff to understand exactly what changed
+3. **Identify scope**: Determine the primary area of impact (e.g., "api", "config", "docs", "fix", "refactor")
+4. **Craft oneliner**: Create a concise summary in the format "{area}: {change}"
+   - Examples: "config: update dataDir handling", "api: add new endpoint for sessions", "fix: resolve memory leak in handler"
+5. **Write detailed body**: Explain:
+   - What changed and why
+   - How it addresses the task
+   - Any important context or decisions made
+   - Potential side effects or follow-ups needed
+
+## Guidelines
+
+- Be specific, not generic ("fix auth token expiry" not "fix bug")
+- Focus on the "why" not just the "what"
+- Use imperative mood ("add feature" not "added feature")
+- Keep the oneliner under 72 characters when possible
+- The detailed message should be comprehensive enough that future agents can understand the context
+
+## Output Format
+
+Output ONLY the commit message in this format:
+
+```
+{oneliner}
+
+{detailed explanation}
+```
+
+Do not include any other text, prefixes like "Commit:" or "Message:", or explanations. Just the commit message itself.

--- a/cmd/flock/main.go
+++ b/cmd/flock/main.go
@@ -41,6 +41,10 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	log.Printf("starting flock (opencode: %s)...", cfg.OpenCodeURL)
 
+	if err := opencode.SyncAgents(); err != nil {
+		log.Printf("warning: failed to sync agents: %v", err)
+	}
+
 	// Open database
 	database, err := db.Open(cfg.DBPath)
 	if err != nil {

--- a/internal/opencode/agents.go
+++ b/internal/opencode/agents.go
@@ -1,0 +1,80 @@
+package opencode
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/nbitslabs/flock/agents"
+)
+
+func SyncAgents() error {
+	agentsDir, err := getAgentsDir()
+	if err != nil {
+		return fmt.Errorf("get agents dir: %w", err)
+	}
+
+	if err := os.MkdirAll(agentsDir, 0755); err != nil {
+		return fmt.Errorf("create agents dir: %w", err)
+	}
+
+	entries, err := fs.ReadDir(agents.FS, ".")
+	if err != nil {
+		return fmt.Errorf("read embedded agents: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if err := syncAgent(agentsDir, name); err != nil {
+			log.Printf("warning: failed to sync agent %s: %v", name, err)
+		}
+	}
+
+	log.Printf("synced flock agents to %s", agentsDir)
+	return nil
+}
+
+func syncAgent(agentsDir, agentName string) error {
+	embeddedContent, err := fs.ReadFile(agents.FS, agentName+".md")
+	if err != nil {
+		return fmt.Errorf("read embedded agent: %w", err)
+	}
+
+	targetPath := filepath.Join(agentsDir, agentName+".md")
+
+	existingContent, err := os.ReadFile(targetPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read existing agent: %w", err)
+	}
+
+	if err == nil && bytes.Equal(existingContent, embeddedContent) {
+		return nil
+	}
+
+	if err := os.WriteFile(targetPath, embeddedContent, 0644); err != nil {
+		return fmt.Errorf("write agent: %w", err)
+	}
+
+	log.Printf("installed/updated agent: %s", agentName)
+	return nil
+}
+
+func getAgentsDir() (string, error) {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home dir: %w", err)
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+
+	return filepath.Join(configHome, "opencode", "agents"), nil
+}


### PR DESCRIPTION
## Summary
- Add custom Opencode agents embedded in the binary
- Implement agent sync on startup that copies flock-* agents to `~/.config/opencode/agents/`
- First agent: `flock-commit-writer` - generates detailed, expressive git commit messages

## Changes
- `agents/` - new directory with embedded markdown agents
- `agents/embed.go` - embeds flock-*.md files
- `internal/opencode/agents.go` - sync logic to copy agents to opencode config dir
- `cmd/flock/main.go` - calls SyncAgents() on startup

Resolves #31