### PR TITLE
Fix #44: Show sub-agents as hierarchical view in UI

### DIFF
--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -40,6 +40,7 @@ type OrchestratorSession struct {
 type Session struct {
 	ID         string
 	InstanceID string
+	ParentID   string
 	Title      string
 	Status     string
 	CreatedAt  string

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -104,9 +104,9 @@ func (q *Queries) CreateOrchestratorSession(ctx context.Context, arg CreateOrche
 }
 
 const createSession = `-- name: CreateSession :one
-INSERT INTO sessions (id, instance_id, title, status)
-VALUES (?, ?, ?, ?)
-RETURNING id, instance_id, title, status, created_at, updated_at
+INSERT INTO sessions (id, instance_id, parent_id, title, status)
+VALUES (?, ?, '', ?, ?)
+RETURNING id, instance_id, parent_id, title, status, created_at, updated_at
 `
 
 type CreateSessionParams struct {
@@ -127,6 +127,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 	err := row.Scan(
 		&i.ID,
 		&i.InstanceID,
+		&i.ParentID,
 		&i.Title,
 		&i.Status,
 		&i.CreatedAt,
@@ -334,7 +335,7 @@ func (q *Queries) GetLastHeartbeatByInstance(ctx context.Context, instanceID str
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, instance_id, title, status, created_at, updated_at FROM sessions WHERE id = ?
+SELECT id, instance_id, parent_id, title, status, created_at, updated_at FROM sessions WHERE id = ?
 `
 
 func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
@@ -343,6 +344,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
 	err := row.Scan(
 		&i.ID,
 		&i.InstanceID,
+		&i.ParentID,
 		&i.Title,
 		&i.Status,
 		&i.CreatedAt,
@@ -494,7 +496,7 @@ func (q *Queries) ListInstances(ctx context.Context) ([]Instance, error) {
 }
 
 const listSessionsByInstance = `-- name: ListSessionsByInstance :many
-SELECT id, instance_id, title, status, created_at, updated_at FROM sessions WHERE instance_id = ? ORDER BY created_at DESC
+SELECT id, instance_id, parent_id, title, status, created_at, updated_at FROM sessions WHERE instance_id = ? ORDER BY created_at DESC
 `
 
 func (q *Queries) ListSessionsByInstance(ctx context.Context, instanceID string) ([]Session, error) {
@@ -509,6 +511,7 @@ func (q *Queries) ListSessionsByInstance(ctx context.Context, instanceID string)
 		if err := rows.Scan(
 			&i.ID,
 			&i.InstanceID,
+			&i.ParentID,
 			&i.Title,
 			&i.Status,
 			&i.CreatedAt,
@@ -743,9 +746,10 @@ func (q *Queries) UpdateTaskStatus(ctx context.Context, arg UpdateTaskStatusPara
 }
 
 const upsertSession = `-- name: UpsertSession :exec
-INSERT INTO sessions (id, instance_id, title, status)
-VALUES (?, ?, ?, ?)
+INSERT INTO sessions (id, instance_id, parent_id, title, status)
+VALUES (?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
+  parent_id = excluded.parent_id,
   title = excluded.title,
   updated_at = datetime('now')
 `
@@ -753,6 +757,7 @@ ON CONFLICT(id) DO UPDATE SET
 type UpsertSessionParams struct {
 	ID         string
 	InstanceID string
+	ParentID   string
 	Title      string
 	Status     string
 }
@@ -761,6 +766,7 @@ func (q *Queries) UpsertSession(ctx context.Context, arg UpsertSessionParams) er
 	_, err := q.db.ExecContext(ctx, upsertSession,
 		arg.ID,
 		arg.InstanceID,
+		arg.ParentID,
 		arg.Title,
 		arg.Status,
 	)

--- a/internal/server/handlers_sessions.go
+++ b/internal/server/handlers_sessions.go
@@ -61,6 +61,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 				s.queries.UpsertSession(r.Context(), sqlc.UpsertSessionParams{
 					ID:         sess.ID,
 					InstanceID: instanceID,
+					ParentID:   sess.ParentID,
 					Title:      sess.Title,
 					Status:     "active",
 				})

--- a/migrations/007_session_parent_id.sql
+++ b/migrations/007_session_parent_id.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN parent_id TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN parent_id;

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1108,18 +1108,65 @@
         if (!list) return;
         const items = Array.from(store.sessions.values());
         if (!items.length) { list.innerHTML = '<p class="text-xs text-gray-400 dark:text-gray-500 py-2">No sessions</p>'; return; }
-        reconcileList(list, items, s => s.id, createSessionEl, updateSessionEl);
+
+        // Build parent -> children map
+        const childrenMap = new Map();
+        const rootSessions = [];
+
+        for (const sess of items) {
+            const pid = sess.parent_id || sess.parentID || '';
+            if (!pid) {
+                rootSessions.push(sess);
+            } else {
+                if (!childrenMap.has(pid)) childrenMap.set(pid, []);
+                childrenMap.get(pid).push(sess);
+            }
+        }
+
+        // Build flattened list with hierarchy info
+        function flattenWithChildren(session, depth = 0) {
+            const result = [{ session, depth }];
+            const children = childrenMap.get(session.id) || [];
+            for (const child of children) {
+                result.push(...flattenWithChildren(child, depth + 1));
+            }
+            return result;
+        }
+
+        const flattened = [];
+        for (const sess of rootSessions) {
+            flattened.push(...flattenWithChildren(sess));
+        }
+
+        // Include any orphaned children (parent not in our list)
+        for (const sess of items) {
+            const pid = sess.parent_id || sess.parentID || '';
+            if (pid && !store.sessions.has(pid)) {
+                flattened.push({ session: sess, depth: 1 });
+            }
+        }
+
+        reconcileList(list, flattened, item => item.session.id,
+            item => createSessionEl(item.session, item.depth),
+            (el, item) => updateSessionEl(el, item.session, item.depth));
     }
 
-    function createSessionEl(sess) {
+    function createSessionEl(sess, depth = 0) {
         const sel = sess.id === store.selectedSessionId;
         const title = sess.title || 'Untitled';
         const busy = sel && store.sessionBusy;
+        const indent = depth * 12;
+        const isSubAgent = depth > 0;
         const div = h('div', {
             className: `flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer text-sm ${sel ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}`,
             'data-action': 'select-session', 'data-id': sess.id, title,
         });
-        div.appendChild(h('span', { className: `w-1.5 h-1.5 rounded-full flex-shrink-0 ${busy ? 'bg-yellow-400 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'}` }));
+        div.style.paddingLeft = `${8 + indent}px`;
+        if (isSubAgent) {
+            div.appendChild(h('span', { className: 'text-xs text-purple-400 dark:text-purple-500', textContent: '\u21b3' }));
+        } else {
+            div.appendChild(h('span', { className: `w-1.5 h-1.5 rounded-full flex-shrink-0 ${busy ? 'bg-yellow-400 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'}` }));
+        }
         div.appendChild(h('span', { className: 'truncate flex-1', textContent: title }));
         div.appendChild(h('button', {
             className: 'text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 text-xs px-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0',
@@ -1128,14 +1175,23 @@
         return div;
     }
 
-    function updateSessionEl(el, sess) {
+    function updateSessionEl(el, sess, depth = 0) {
         const sel = sess.id === store.selectedSessionId;
         const title = sess.title || 'Untitled';
         const busy = sel && store.sessionBusy;
+        const isSubAgent = depth > 0;
+        el.style.paddingLeft = `${8 + depth * 12}px`;
         el.className = `flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer text-sm ${sel ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}`;
         el.title = title;
         const dot = el.querySelector('span:first-child');
-        if (dot) dot.className = `w-1.5 h-1.5 rounded-full flex-shrink-0 ${busy ? 'bg-yellow-400 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'}`;
+        if (dot) {
+            if (isSubAgent) {
+                dot.className = 'text-xs text-purple-400 dark:text-purple-500';
+                dot.textContent = '\u21b3';
+            } else {
+                dot.className = `w-1.5 h-1.5 rounded-full flex-shrink-0 ${busy ? 'bg-yellow-400 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'}`;
+            }
+        }
         const children = Array.from(el.children);
         const titleEl = children[1];
         if (titleEl && titleEl.textContent !== title) titleEl.textContent = title;


### PR DESCRIPTION
## Summary
- Added `parent_id` column to sessions table via new migration
- Updated database models and queries to include parent_id in Session struct
- Modified frontend to render sessions hierarchically with proper indentation and indicators

## Changes

### Database
- Added `migrations/007_session_parent_id.sql` - adds `parent_id TEXT NOT NULL DEFAULT ''` to sessions table
- Updated `internal/db/sqlc/models.go` - added `ParentID` field to Session struct
- Updated `internal/db/sqlc/queries.sql.go` - modified CreateSession, GetSession, ListSessionsByInstance, and UpsertSession queries
- Updated `internal/server/handlers_sessions.go` - passes ParentID when upserting sessions

### Frontend
- Modified `web/static/app.js` to support hierarchical session display:
  - Builds parent-to-children mapping from session data
  - Supports both `parent_id` (database) and `parentID` (OpenCode API) for flexibility
  - Renders sessions with 12px indentation per depth level
  - Shows purple arrow (⇳) indicator for sub-agent sessions instead of status dot
  - Handles orphaned children (sessions whose parent is no longer in the list)

## Testing
- Sessions without a parent_id display as root sessions with normal status indicator
- Sessions with a parent_id are indented and show the sub-agent indicator
- Both database parent_id and OpenCode API parentID are supported for compatibility

Fixes #44