### PR TITLE
refactor: unify flock-agent session handling with regular session APIs (Fixes #58)

### DIFF
--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -143,6 +143,9 @@ UPDATE flock_agent_sessions SET session_id = ?, status = ?, updated_at = datetim
 -- name: RetireFlockAgentSession :exec
 UPDATE flock_agent_sessions SET status = 'retired', updated_at = datetime('now') WHERE id = ?;
 
+-- name: GetActiveFlockAgentSessionByInstance :one
+SELECT * FROM sessions WHERE instance_id = 'flock-agent' AND status = 'active' LIMIT 1;
+
 -- Auth session queries
 
 -- name: CreateAuthSession :one

--- a/internal/db/sqlc/queries.sql.go
+++ b/internal/db/sqlc/queries.sql.go
@@ -43,6 +43,7 @@ type CreateAuthSessionParams struct {
 	Username string
 }
 
+// Auth session queries
 func (q *Queries) CreateAuthSession(ctx context.Context, arg CreateAuthSessionParams) (AuthSession, error) {
 	row := q.db.QueryRowContext(ctx, createAuthSession, arg.Token, arg.Username)
 	var i AuthSession
@@ -307,6 +308,25 @@ func (q *Queries) GetActiveFlockAgentSession(ctx context.Context) (FlockAgentSes
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getActiveFlockAgentSessionByInstance = `-- name: GetActiveFlockAgentSessionByInstance :one
+SELECT id, instance_id, title, status, created_at, updated_at, parent_id FROM sessions WHERE instance_id = 'flock-agent' AND status = 'active' LIMIT 1
+`
+
+func (q *Queries) GetActiveFlockAgentSessionByInstance(ctx context.Context) (Session, error) {
+	row := q.db.QueryRowContext(ctx, getActiveFlockAgentSessionByInstance)
+	var i Session
+	err := row.Scan(
+		&i.ID,
+		&i.InstanceID,
+		&i.Title,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
 	)
 	return i, err
 }

--- a/internal/server/handlers_agent.go
+++ b/internal/server/handlers_agent.go
@@ -156,18 +156,16 @@ func (s *Server) handleGetAgentStatus(w http.ResponseWriter, r *http.Request) {
 
 // ensureFlockAgentSession returns a valid flock agent session, creating a new
 // one if the existing session no longer exists in OpenCode.
-func (s *Server) ensureFlockAgentSession(ctx context.Context) (*sqlc.FlockAgentSession, error) {
-	session, err := s.queries.GetActiveFlockAgentSession(ctx)
+func (s *Server) ensureFlockAgentSession(ctx context.Context) (*sqlc.Session, error) {
+	session, err := s.queries.GetActiveFlockAgentSessionByInstance(ctx)
 	if err == nil {
-		// Verify the OpenCode session still exists
-		if _, err := s.flockAgentClient.GetSession(ctx, session.SessionID); err == nil {
+		if _, err := s.flockAgentClient.GetSession(ctx, session.ID); err == nil {
 			return &session, nil
 		}
-		log.Printf("flock agent session %s no longer exists in opencode, recreating", session.SessionID[:12])
-		s.queries.RetireFlockAgentSession(ctx, session.ID)
+		log.Printf("flock agent session %s no longer exists in opencode, recreating", session.ID[:12])
+		s.queries.DeleteSession(ctx, session.ID)
 	}
 
-	// Create a new session
 	ocSession, err := s.flockAgentClient.CreateSession(ctx, s.dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("create flock agent session: %w", err)
@@ -178,17 +176,17 @@ func (s *Server) ensureFlockAgentSession(ctx context.Context) (*sqlc.FlockAgentS
 		sessionID = uuid.New().String()
 	}
 
-	flockAgentID := uuid.New().String()
-	newSession, err := s.queries.CreateFlockAgentSession(ctx, sqlc.CreateFlockAgentSessionParams{
-		ID:               flockAgentID,
-		SessionID:        sessionID,
-		WorkingDirectory: s.dataDir,
+	newSession, err := s.queries.CreateSession(ctx, sqlc.CreateSessionParams{
+		ID:         sessionID,
+		InstanceID: flockAgentInstanceID,
+		Title:      ocSession.Title,
+		Status:     "active",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("save flock agent session: %w", err)
 	}
 
-	log.Printf("created new flock agent session %s (opencode: %s)", flockAgentID[:8], sessionID[:12])
+	log.Printf("created new flock agent session %s (opencode: %s)", sessionID[:8], sessionID[:12])
 	return &newSession, nil
 }
 
@@ -218,16 +216,16 @@ func (s *Server) handleCreateFlockAgentSession(w http.ResponseWriter, r *http.Re
 
 	writeJSON(w, map[string]any{
 		"id":         session.ID,
-		"session_id": session.SessionID,
+		"session_id": session.ID,
 		"status":     session.Status,
 	})
 }
 
 // handleRotateFlockAgentSession rotates (retires old and creates new) the Flock agent session.
 func (s *Server) handleRotateFlockAgentSession(w http.ResponseWriter, r *http.Request) {
-	activeSession, err := s.queries.GetActiveFlockAgentSession(r.Context())
+	activeSession, err := s.queries.GetActiveFlockAgentSessionByInstance(r.Context())
 	if err == nil && activeSession.Status == "active" {
-		s.queries.RetireFlockAgentSession(r.Context(), activeSession.ID)
+		s.queries.DeleteSession(r.Context(), activeSession.ID)
 	}
 
 	ocSession, err := s.flockAgentClient.CreateSession(r.Context(), s.dataDir)
@@ -242,11 +240,11 @@ func (s *Server) handleRotateFlockAgentSession(w http.ResponseWriter, r *http.Re
 		sessionID = uuid.New().String()
 	}
 
-	flockAgentID := uuid.New().String()
-	_, err = s.queries.CreateFlockAgentSession(r.Context(), sqlc.CreateFlockAgentSessionParams{
-		ID:               flockAgentID,
-		SessionID:        sessionID,
-		WorkingDirectory: s.dataDir,
+	newSession, err := s.queries.CreateSession(r.Context(), sqlc.CreateSessionParams{
+		ID:         sessionID,
+		InstanceID: flockAgentInstanceID,
+		Title:      ocSession.Title,
+		Status:     "active",
 	})
 	if err != nil {
 		log.Printf("failed to save flock agent session: %v", err)
@@ -255,9 +253,9 @@ func (s *Server) handleRotateFlockAgentSession(w http.ResponseWriter, r *http.Re
 	}
 
 	writeJSON(w, map[string]any{
-		"id":     flockAgentID,
-		"session_id": sessionID,
-		"status": "active",
+		"id":         newSession.ID,
+		"session_id": newSession.ID,
+		"status":     newSession.Status,
 	})
 }
 
@@ -269,7 +267,7 @@ func (s *Server) handleGetFlockAgentMessages(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	messages, err := s.flockAgentClient.GetMessages(r.Context(), session.SessionID)
+	messages, err := s.flockAgentClient.GetMessages(r.Context(), session.ID)
 	if err != nil {
 		log.Printf("failed to get flock agent messages: %v", err)
 		http.Error(w, "failed to get messages", http.StatusInternalServerError)
@@ -292,7 +290,7 @@ func (s *Server) handleSendFlockAgentMessage(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := s.flockAgentClient.SendMessage(r.Context(), session.SessionID, req.Content); err != nil {
+	if err := s.flockAgentClient.SendMessage(r.Context(), session.ID, req.Content); err != nil {
 		log.Printf("failed to send flock agent message: %v", err)
 		http.Error(w, "failed to send message", http.StatusInternalServerError)
 		return
@@ -310,5 +308,5 @@ func (s *Server) handleFlockAgentEvents(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	s.broker.ServeHTTP(w, r, session.SessionID)
+	s.broker.ServeHTTP(w, r, session.ID)
 }

--- a/internal/server/handlers_sessions.go
+++ b/internal/server/handlers_sessions.go
@@ -10,6 +10,19 @@ import (
 	"github.com/nbitslabs/flock/internal/opencode"
 )
 
+const flockAgentInstanceID = "flock-agent"
+
+func (s *Server) getClientForSession(session *sqlc.Session) *opencode.Client {
+	if session.InstanceID == flockAgentInstanceID {
+		return s.flockAgentClient
+	}
+	inst, ok := s.manager.Get(session.InstanceID)
+	if !ok {
+		return nil
+	}
+	return inst.Client
+}
+
 func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	instanceID := r.PathValue("id")
 	// Verify instance exists
@@ -119,10 +132,8 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to get from OpenCode
-	inst, ok := s.manager.Get(session.InstanceID)
-	if ok && inst.Client != nil {
-		// Return DB session enriched with instance info
+	client := s.getClientForSession(&session)
+	if client != nil {
 		writeJSON(w, map[string]any{
 			"id":          session.ID,
 			"instance_id": session.InstanceID,
@@ -145,13 +156,13 @@ func (s *Server) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	inst, ok := s.manager.Get(session.InstanceID)
-	if !ok || inst.Client == nil {
+	client := s.getClientForSession(&session)
+	if client == nil {
 		http.Error(w, "instance not available", http.StatusServiceUnavailable)
 		return
 	}
 
-	messages, err := inst.Client.GetMessages(r.Context(), sessionID)
+	messages, err := client.GetMessages(r.Context(), sessionID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -177,13 +188,13 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	inst, ok := s.manager.Get(session.InstanceID)
-	if !ok || inst.Client == nil {
+	client := s.getClientForSession(&session)
+	if client == nil {
 		http.Error(w, "instance not available", http.StatusServiceUnavailable)
 		return
 	}
 
-	if err := inst.Client.SendMessage(r.Context(), sessionID, req.Content); err != nil {
+	if err := client.SendMessage(r.Context(), sessionID, req.Content); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -205,9 +216,9 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	inst, ok := s.manager.Get(session.InstanceID)
-	if ok && inst.Client != nil {
-		if err := inst.Client.DeleteSession(r.Context(), sessionID); err != nil {
+	client := s.getClientForSession(&session)
+	if client != nil {
+		if err := client.DeleteSession(r.Context(), sessionID); err != nil {
 			log.Printf("failed to delete session from opencode: %v", err)
 		}
 	}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -355,7 +355,9 @@
 
     async function loadFlockAgentMessages() {
         try {
-            const msgs = await api('GET', '/api/flock-agent/messages') || [];
+            const sessionId = store.flockAgentSessionId;
+            if (!sessionId) return;
+            const msgs = await api('GET', `/api/sessions/${sessionId}/messages`) || [];
             store.messages.clear();
             for (const m of msgs) {
                 if (!m.info?.id) continue;
@@ -369,7 +371,9 @@
 
     async function sendFlockAgentMessage(content) {
         try {
-            await api('POST', '/api/flock-agent/messages', { content });
+            const sessionId = store.flockAgentSessionId;
+            if (!sessionId) return;
+            await api('POST', `/api/sessions/${sessionId}/messages`, { content });
         } catch (e) {
             console.error('sendFlockAgentMessage:', e);
             alert('Failed to send message: ' + e.message);
@@ -380,7 +384,9 @@
 
     function connectFlockAgentSSE() {
         closeEventSource();
-        const es = new EventSource('/api/flock-agent/events');
+        const sessionId = store.flockAgentSessionId;
+        if (!sessionId) return;
+        const es = new EventSource(`/api/sessions/${sessionId}/events`);
         store.eventSource = es;
         es.onmessage = function (e) {
             try { routeEvent(JSON.parse(e.data)); } catch (err) { /* ignore */ }


### PR DESCRIPTION
## Summary
- Refactor flock-agent to use unified session APIs instead of separate endpoints
- Store flock-agent sessions in the main `sessions` table with `instance_id = 'flock-agent'`
- Add `getClientForSession` helper to handle the special flock-agent instance ID
- Update frontend to use unified `/api/sessions/{id}/messages` and `/api/sessions/{id}/events` endpoints
- This eliminates code duplication between flock-agent and regular session handling

## Changes
- **handlers_sessions.go**: Added `flockAgentInstanceID` constant and `getClientForSession` helper function
- **handlers_agent.go**: Updated to use main `sessions` table instead of `flock_agent_sessions` table
- **queries.sql**: Added `GetActiveFlockAgentSessionByInstance` query
- **app.js**: Updated to use unified session endpoints

Fixes #58