### PR TITLE
Fix #69: Auto-accept GitHub SSH host key on fresh installations

### DIFF
--- a/internal/server/handlers_instances.go
+++ b/internal/server/handlers_instances.go
@@ -73,6 +73,11 @@ func cloneOrGetRepo(basePath, org, repo string) (string, error) {
 		return "", err
 	}
 
+	// Ensure GitHub SSH host key is whitelisted before clone
+	if err := ensureGitHubHostKey(basePath); err != nil {
+		return "", err
+	}
+
 	gitURL := "git@github.com:" + org + "/" + repo + ".git"
 	cmd := exec.Command("git", "clone", "--depth", "1", gitURL, repoPath)
 	cmd.Dir = orgPath
@@ -81,6 +86,44 @@ func cloneOrGetRepo(basePath, org, repo string) (string, error) {
 	}
 
 	return repoPath, nil
+}
+
+// ensureGitHubHostKey adds GitHub's SSH host key to known_hosts if not already present.
+// This prevents "Host key verification failed" errors on fresh installations.
+func ensureGitHubHostKey(basePath string) error {
+	knownHostsPath := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
+
+	// Create .ssh directory if it doesn't exist
+	sshDir := filepath.Join(os.Getenv("HOME"), ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		return err
+	}
+
+	// Check if github.com is already in known_hosts
+	if data, err := os.ReadFile(knownHostsPath); err == nil {
+		if strings.Contains(string(data), "github.com") {
+			return nil
+		}
+	}
+
+	// Add github.com host key to known_hosts
+	cmd := exec.Command("ssh-keyscan", "github.com")
+	out, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(knownHostsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(out); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Server) handleListInstances(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Added `ensureGitHubHostKey` function that automatically whitelists GitHub's SSH host key before git clone operations
- The function runs `ssh-keyscan github.com` to fetch and add the host key to `~/.ssh/known_hosts`
- Only adds the key if not already present to avoid unnecessary I/O

## Problem
When flock is set up on a new machine for the first time, the first git clone when adding a new repository fails because the SSH host keys are not whitelisted. This requires manual intervention to accept the host key.

## Solution
Before performing any SSH-based git clone (in `cloneOrGetRepo`), the code now ensures GitHub's SSH host key is in the known_hosts file. This prevents "Host key verification failed" errors on fresh installations.

## Testing
- Verified the code compiles successfully
- The function is idempotent - it only adds the key if not already present

Fixes #69